### PR TITLE
[fix-uri] remove '/' from resources uri

### DIFF
--- a/API/AbstractHydraResourceApi.php
+++ b/API/AbstractHydraResourceApi.php
@@ -16,6 +16,6 @@ abstract class AbstractHydraResourceApi extends AbstractResourceApi
      */
     public function getResourceURI($input)
     {
-        return '/'.$this->pluralResourceName.'/'.$input;
+        return $this->pluralResourceName.'/'.$input;
     }
 }

--- a/Tests/API/AbstractHydraResourceApiTest.php
+++ b/Tests/API/AbstractHydraResourceApiTest.php
@@ -21,6 +21,6 @@ class AbstractHydraResourceApiTest extends \PHPUnit_Framework_TestCase
     {
         $api = new TestHydraResourceApi('tests');
         $result = $api->getResourceURI(1);
-        $this->assertEquals('/tests/1', $result);
+        $this->assertEquals('tests/1', $result);
     }
 }

--- a/Tests/API/ResourceApiTest.php
+++ b/Tests/API/ResourceApiTest.php
@@ -36,7 +36,7 @@ class ResourceApiTest extends AbstractResourceApiTester
 
     public function testGet()
     {
-        $uri = '/resource/1';
+        $uri = 'resource/1';
         $result = array('property' => 'value');
         $this->_getTest($uri, $result, $this->authentificationMock);
 
@@ -46,7 +46,7 @@ class ResourceApiTest extends AbstractResourceApiTester
 
     public function testUpdate()
     {
-        $uri = '/resource/1';
+        $uri = 'resource/1';
         $data = array('property' => 'value');
         $requestHeaders = array('Content-Type' => 'application/json');
         $result = '{"resource" : 1}';
@@ -59,7 +59,7 @@ class ResourceApiTest extends AbstractResourceApiTester
 
     public function testCreate()
     {
-        $uri = '/resource';
+        $uri = 'resource';
         $data = array('property' => 'value');
         $requestHeaders = array('Content-Type' => 'application/json');
         $result = '{"resource" : 1}';
@@ -72,7 +72,7 @@ class ResourceApiTest extends AbstractResourceApiTester
 
     public function testDelete()
     {
-        $uri = '/resource/1';
+        $uri = 'resource/1';
         $result = true;
 
         $this->_deleteTest($uri, $this->authentificationMock, $result);


### PR DESCRIPTION
When generate the URI for an hydra resource, not add '/' in the beginning of the uri. Guzzle automatically add it, and if you do so he can change the base url.

Linked to https://github.com/lafourchette/lafourchette-rr/pull/4387